### PR TITLE
Gives pilots EVA and External Airlock access

### DIFF
--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -81,8 +81,8 @@ var/const/access_explorer = 43
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/pilot
 	economic_modifier = 5 //VOREStation Edit
-	access = list(access_pilot) //VOREStation Edit
-	minimal_access = list(access_pilot) //VOREStation Edit
+	access = list(access_pilot, access_eva) //MITHRAstation Edit
+	minimal_access = list(access_pilot, access_eva) //Mithrastation Edit
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 
 /datum/job/explorer

--- a/maps/southern_cross/southern_cross_jobs.dm
+++ b/maps/southern_cross/southern_cross_jobs.dm
@@ -81,8 +81,8 @@ var/const/access_explorer = 43
 	selection_color = "#515151"
 	idtype = /obj/item/weapon/card/id/civilian/pilot
 	economic_modifier = 5 //VOREStation Edit
-	access = list(access_pilot, access_eva) //MITHRAstation Edit
-	minimal_access = list(access_pilot, access_eva) //Mithrastation Edit
+	access = list(access_pilot, access_eva, access_external_airlocks) //MITHRAstation Edit
+	minimal_access = list(access_pilot, access_eva, access_external_airlocks) //Mithrastation Edit
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 
 /datum/job/explorer


### PR DESCRIPTION
Pilots need EVA  and External Airlock access! This is mostly so they can open the airlock that they can dock onto in arrivals, and perhaps get some spare space suits for their passengers