### PR TITLE
Fixes Custom Species being "Custom Species" instead of the Custom Species

### DIFF
--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -56,6 +56,8 @@
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
 		var/use_name = "\improper [H.species.name]"
+		if(H.custom_species)
+			use_name = "\improper [H.custom_species]"
 		species_text = " for \a [use_name]"
 	. = "[get_third_person_message_start(my_gender)] [get_standalone_value_descriptor(my_value)][species_text]"
 

--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -56,8 +56,8 @@
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
 		var/use_name = "\improper [H.species.name]"
-		if(H.custom_species)
-			use_name = "\improper [H.custom_species]"
+		if(H.custom_species) //MithraStation change
+			use_name = "\improper [H.custom_species]" //MithraStation change
 		species_text = " for \a [use_name]"
 	. = "[get_third_person_message_start(my_gender)] [get_standalone_value_descriptor(my_value)][species_text]"
 


### PR DESCRIPTION
Have you ever noticed that when you examine a custom species (assuming you're not also a custom species) you get a message akin to this:

She is of average height for a Custom Species, and about as tall as you
She is thin for a Custom Species, and thinner than you

This fixes that, so instead you will see

She is of average height for a Wolfgirl, and about as tall as you
She is thin for a Wolfgirl, and thinner than you

(or whatever the name of the particular character's species is. You get the idea!)