### PR TITLE
Pilot helmets cover the eyes

### DIFF
--- a/modular_mithra/code/modules/clothing/head/pilot_helmet.dm
+++ b/modular_mithra/code/modules/clothing/head/pilot_helmet.dm
@@ -1,0 +1,2 @@
+/obj/item/clothing/head/pilot
+	body_parts_covered = HEAD|EYES


### PR DESCRIPTION
What's this? Another self serving pilot PR from cebu? Preposterous! 

Anyways, the pilot helmet's sprite covers the eyes and it gives a HUD, which means it should probably cover the eyes. Probably has no real gameplay implications.