### PR TITLE
Makes the X-01 Multiphase Energy Gun holsterable

### DIFF
--- a/mithrastation.dme
+++ b/mithrastation.dme
@@ -2958,6 +2958,7 @@
 #include "modular_mithra\code\game\objects\items\weapons\tools.dm"
 #include "modular_mithra\code\modules\clothing\glasses\glasses.dm"
 #include "modular_mithra\code\modules\paperwork\paper.dm"
+#include "modular_mithra\code\modules\projectiles\guns\energy\laser.dm"
 #include "modular_mithra\loadout\loadout_eyes.dm"
 #include "modular_mithra\loadout\loadout_general.dm"
 #include "modular_mithra\loadout\loadout_head.dm"

--- a/modular_mithra/code/modules/projectiles/guns/energy/laser.dm
+++ b/modular_mithra/code/modules/projectiles/guns/energy/laser.dm
@@ -1,0 +1,6 @@
+/*
+		MITHRA's lasergun overrides and stuff go here
+*/
+
+/obj/item/weapon/gun/energy/captain
+	slot_flags = SLOT_BELT|SLOT_HOLSTER

--- a/modular_mithra/multiphase/gun.dm
+++ b/modular_mithra/multiphase/gun.dm
@@ -13,7 +13,7 @@
 	icon_state = "multiphasedis100"
 	projectile_type = /obj/item/projectile/beam/stun/disabler
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_POWER = 3)
-	slot_flags = SLOT_BELT
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	force = 10 //for the HOS to lay down a good beating in desperate situations. Holdover from TG.
 	w_class = ITEMSIZE_NORMAL
 	fire_delay = 6	//standard rate


### PR DESCRIPTION
:cl: Toriate
add: The multiphase gun now fits in holsters. Rejoice!
/:cl:

Does exactly what it says on the tin. HOS players have stated the utility of holsterable guns.