### PR TITLE
Round Extension

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -7,7 +7,7 @@ datum/controller/transfer_controller
 	var/shift_last_vote = 0 //VOREStation Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
-	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 1) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
+	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 4) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
 	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval //VOREStation Edit
 	processing_objects += src
 


### PR DESCRIPTION
Extends the round autotransfer from starting at 4 hours to 7, thus extending the rounds to 8 hour maximum rounds.