### PR TITLE
Removes and restricts size changing

### DIFF
--- a/code/game/machinery/vending_vr.dm
+++ b/code/game/machinery/vending_vr.dm
@@ -1,7 +1,11 @@
 //Tweaked existing vendors
+
+/* MITHRA EDIT: Makes size shrooms unobtainable through normal means
+
 /obj/machinery/vending/hydroseeds/New()
 	products += list(/obj/item/seeds/shrinkshroom = 3,/obj/item/seeds/megashroom = 3)
 	..()
+/END OF MITHRA EDIT */
 
 /obj/machinery/vending/security/New()
 	products += list(/obj/item/weapon/gun/energy/taser = 8,/obj/item/weapon/gun/energy/stunrevolver = 4,

--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -220,7 +220,7 @@
 	var/path = pick(prob(6);/obj/item/weapon/storage/pill_bottle/tramadol,
 					prob(4);/obj/item/weapon/storage/pill_bottle/happy,
 					prob(4);/obj/item/weapon/storage/pill_bottle/zoom,
-					prob(4);/obj/item/weapon/gun/energy/sizegun,
+				//	prob(4);/obj/item/weapon/gun/energy/sizegun, MITHRA edit: makes sizegun unobtainable via trash piles
 					prob(3);/obj/item/weapon/material/butterfly,
 					prob(3);/obj/item/weapon/material/butterfly/switchblade,
 					prob(3);/obj/item/clothing/gloves/knuckledusters,

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -59,8 +59,8 @@
 
 /datum/category_item/player_setup_item/vore/size/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["size_multiplier"])
-		var/new_size = input(user, "Choose your character's size, ranging from 25% to 200%", "Set Size") as num|null
-		if (!IsInRange(new_size,25,200))
+		var/new_size = input(user, "Choose your character's size, ranging from 75% to 125%", "Set Size") as num|null //Mithra EDIT- restricts character size to 75-125, from 25-200
+		if (!IsInRange(new_size,75,125)) //Mithra EDIT- restricts character size to 75-125, from 25-200
 			pref.size_multiplier = 1
 			user << "<span class='notice'>Invalid size.</span>"
 			return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -124,6 +124,7 @@
 	list_pos = NIF_SIZECHANGE
 	cost = 750
 	wear = 6
+	vended = FALSE //MithraEdit: Makes the sizechange NIF unobtainable through normal means
 
 	activate()
 		if((. = ..()))

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -9,6 +9,7 @@
 	catalysts = list("phoron" = 5)
 	result_amount = 5
 
+/* MITHRA Edit: Makes sizechems unobtainable from chemistry
 /datum/chemical_reaction/macrocillin
 	name = "Macrocillin"
 	id = "macrocillin"
@@ -32,6 +33,7 @@
 	// POLARISTODO requires_heating = 1
 	required_reagents = list("sizeoxadone" = 20, "leporazine" = 20)
 	result_amount = 1
+*/
 
 /datum/chemical_reaction/dontcrossthebeams
 	name = "Don't Cross The Beams"

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -13,6 +13,7 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 2000, "glass" = 2000)
 	build_path = /obj/item/weapon/implantcase/backup
 
+/* Mithra edit: makes sizegun and bluespace jumpsuit unobtainable through research
 /datum/design/item/weapon/sizegun
 	name = "Size gun"
 	id = "sizegun"
@@ -21,6 +22,7 @@
 	build_path = /obj/item/weapon/gun/energy/sizegun
 	sort_string = "TAAAB"
 
+
 /datum/design/item/bluespace_jumpsuit
 	name = "Bluespace jumpsuit"
 	id = "bsjumpsuit"
@@ -28,6 +30,9 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
 	build_path = /obj/item/clothing/under/bluespace
 	sort_string = "TAAAC"
+
+
+/End of Mithra Edit	*/
 
 /datum/design/item/sleevemate
 	name = "SleeveMate 3700"

--- a/code/modules/resleeving/designer.dm
+++ b/code/modules/resleeving/designer.dm
@@ -309,8 +309,8 @@
 		return
 
 	if(href_list["size_multiplier"])
-		var/new_size = input(user, "Choose your character's size, ranging from 25% to 200%", "Character Preference") as num|null
-		if(new_size && IsInRange(new_size,25,200))
+		var/new_size = input(user, "Choose your character's size, ranging from 75% to 125%", "Character Preference") as num|null
+		if(new_size && IsInRange(new_size,75,125))
 			active_br.sizemult = (new_size/100)
 			preview_icon = null
 		return 1

--- a/code/modules/virus2/effect_vr.dm
+++ b/code/modules/virus2/effect_vr.dm
@@ -38,6 +38,7 @@
 ///////////////////////////////////////////////
 /////////////////// Stage 3 ///////////////////
 
+/* MITHRA edit: removes size disease
 /datum/disease2/effect/size
 	name = "Mass Revectoring"
 	stage = 3
@@ -47,6 +48,7 @@
 		var/newsize = rand (25, 200)
 		mob.resize(newsize/100)
 		viewers(mob) << "<span class='warning'>[mob.name] suddenly changes size!</span>"
+/End of Mithra edit */
 
 /datum/disease2/effect/flip
 	name = "Flipponov's Disease"

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -641,10 +641,10 @@
 			selected.bulge_size = (new_bulge/100)
 
 	if(href_list["b_grow_shrink"])
-		var/new_grow = input(user, "Choose the size that prey will be grown/shrunk to, ranging from 25% to 200%", "Set Growth Shrink Size.", selected.shrink_grow_size) as num|null
+		var/new_grow = input(user, "Choose the size that prey will be grown/shrunk to, ranging from 75% to 125%", "Set Growth Shrink Size.", selected.shrink_grow_size) as num|null //Mithra edit: restricts sizing
 		if (new_grow == null)
 			return
-		if (!IsInRange(new_grow,25,200))
+		if (!IsInRange(new_grow,75,125)) //Mithra edit: restricts sizing
 			selected.shrink_grow_size = 1 //Set it to the default
 			to_chat(user,"<span class='notice'>Invalid size.</span>")
 		else if(new_grow)

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -109,7 +109,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 
 	var/nagmessage = "Adjust your mass to be a size between 25 to 200% (DO NOT ABUSE)"
 	var/new_size = input(nagmessage, "Pick a Size") as num|null
-	if(new_size && IsInRange(new_size,25,200))
+	if(new_size && IsInRange(new_size,75,125)) //Mithra edit: restricts sizing
 		src.resize(new_size/100)
 		message_admins("[key_name(src)] used the resize command in-game to be [new_size]% size. \
 			([src ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>" : "null"])")


### PR DESCRIPTION
Basically, this restricts character size to 75%-125% of normal, as opposed to 25%-200%. This is more inline with the more realistic setting we're trying to develop.

Additionally, all (or at least, I hope so) of the ways to change your size ingame have been removed from normal accessibility. Admins can still spawn them. This removes:

-The ability to print the sizegun and bluespace jumpsuit from research
-The ability to find a sizegun in trash piles
-Size changing virus symptoms
-The chemistry recipies for the size chems
-The mega/micro mushrooms from the plant machine

If there's anything I forgot, please let me know!