### PR TITLE
Radios now get a panic function.

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -121,6 +121,9 @@ var/const/SRV_FREQ = 1349
 var/const/SUP_FREQ = 1347
 var/const/EXP_FREQ = 1361
 
+//Mithra addition: Panic channel
+var/const/PANIC_FREQ = 1333
+
 // internal department channels
 var/const/MED_I_FREQ = 1485
 var/const/SEC_I_FREQ = 1475
@@ -142,7 +145,8 @@ var/list/radiochannels = list(
 	"AI Private"	= AI_FREQ,
 	"Entertainment" = ENT_FREQ,
 	"Medical(I)"	= MED_I_FREQ,
-	"Security(I)"	= SEC_I_FREQ
+	"Security(I)"	= SEC_I_FREQ,
+	"Emergency"		= PANIC_FREQ			//Mithra addition
 )
 
 // central command channels, i.e deathsquid & response teams
@@ -189,6 +193,10 @@ var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, SEC
 		return "entradio"
 	if(frequency in DEPT_FREQS)
 		return "deptradio"
+
+// Mithra addition: Panic button frequency
+	if(frequency == PANIC_FREQ)
+		return "emergradio"
 
 	return "radio"
 

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -122,7 +122,7 @@ var/const/SUP_FREQ = 1347
 var/const/EXP_FREQ = 1361
 
 //Mithra addition: Panic channel
-var/const/PANIC_FREQ = 1331
+var/const/PANIC_FREQ = 1469
 
 // internal department channels
 var/const/MED_I_FREQ = 1485
@@ -156,7 +156,7 @@ var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 var/list/ANTAG_FREQS = list(SYND_FREQ, RAID_FREQ)
 
 //Department channels, arranged lexically
-var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, PANIC_FREQ)
+var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, PANIC_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ)	//Mithra edit: Added panic frequency to department channels.
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -122,7 +122,7 @@ var/const/SUP_FREQ = 1347
 var/const/EXP_FREQ = 1361
 
 //Mithra addition: Panic channel
-var/const/PANIC_FREQ = 1333
+var/const/PANIC_FREQ = 1331
 
 // internal department channels
 var/const/MED_I_FREQ = 1485
@@ -156,12 +156,17 @@ var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 var/list/ANTAG_FREQS = list(SYND_FREQ, RAID_FREQ)
 
 //Department channels, arranged lexically
-var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ)
+var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ, PANIC_FREQ)
 
 #define TRANSMISSION_WIRE	0
 #define TRANSMISSION_RADIO	1
 
 /proc/frequency_span_class(var/frequency)
+
+// Mithra addition: Panic button frequency
+	if(frequency == PANIC_FREQ)
+		return "emergradio"
+
 	// Antags!
 	if (frequency in ANTAG_FREQS)
 		return "syndradio"
@@ -193,10 +198,6 @@ var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, ENT_FREQ, MED_FREQ, SEC
 		return "entradio"
 	if(frequency in DEPT_FREQS)
 		return "deptradio"
-
-// Mithra addition: Panic button frequency
-	if(frequency == PANIC_FREQ)
-		return "emergradio"
 
 	return "radio"
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -12,7 +12,10 @@ var/global/list/default_internal_channels = list(
 	num2text(SEC_I_FREQ)=list(access_security),
 	num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 	num2text(SUP_FREQ) = list(access_cargo),
-	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics)
+	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
+	
+	//Mithra addition - panic button
+	num2text(PANIC_FREQ) = list(access_medical_equip,access_security)	//Security and medics - sec so if something is going down they can hear, medics so they can respond if the person who activated it was on the verge of incap
 )
 
 var/global/list/default_medbay_channels = list(
@@ -48,6 +51,9 @@ var/global/list/default_medbay_channels = list(
 	throw_range = 9
 	w_class = ITEMSIZE_SMALL
 	show_messages = 1
+	
+	//Mithra addition: Frequency lock. In this file instead of modular/radio_panic_button/radio.dm for ease of sight-read debugging.
+	var/freqlock = FALSE		//lock the frequency, be it for panic functionality or radios we just don't want players toying with the channel knob on
 
 	matter = list("glass" = 25,DEFAULT_WALL_MATERIAL = 75)
 	var/const/FREQ_LISTENING = 1
@@ -200,6 +206,9 @@ var/global/list/default_medbay_channels = list(
 		. = 1
 
 	else if (href_list["freq"])
+		// // // BEGIN MITHRA EDIT: Frequency lock.
+		if(freqlock)	//Mithra edit
+			return FALSE
 		var/new_frequency = (frequency + text2num(href_list["freq"]))
 		if ((new_frequency < PUBLIC_LOW_FREQ || new_frequency > PUBLIC_HIGH_FREQ))
 			new_frequency = sanitize_frequency(new_frequency)
@@ -224,7 +233,9 @@ var/global/list/default_medbay_channels = list(
 	else if(href_list["spec_freq"])
 		var freq = href_list["spec_freq"]
 		if(has_channel_access(usr, freq))
-			set_frequency(text2num(freq))
+			if(!freqlock)		//Mithra edit
+				set_frequency(text2num(freq))
+			// // // END MITHRA EDIT // // //
 		. = 1
 	if(href_list["nowindow"]) // here for pAIs, maybe others will want it, idk
 		return 1

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -15,7 +15,7 @@ var/global/list/default_internal_channels = list(
 	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
 	
 	//Mithra addition - panic button
-	num2text(PANIC_FREQ) = list(access_medical_equip,access_security)		//Security and medical should be able to hear your screams for help. Security so that they can hear your assailant taunt your, medical so they can figure out about where you are and save your dying ass.
+	num2text(PANIC_FREQ) = list(access_medical_equip,access_security)		//Security and medical should be able to hear your screams for help. Security so that they can hear your assailant taunt you, medical so they can figure out about where you are and save your dying ass.
 )
 
 var/global/list/default_medbay_channels = list(

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -15,7 +15,7 @@ var/global/list/default_internal_channels = list(
 	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
 	
 	//Mithra addition - panic button
-	num2text(PANIC_FREQ) = list(access_medical_equip,access_security)	//Security and medics - sec so if something is going down they can hear, medics so they can respond if the person who activated it was on the verge of incap
+	num2text(PANIC_FREQ) = list(access_medical_equip,access_security)		//Security and medical should be able to hear your screams for help. Security so that they can hear your assailant taunt your, medical so they can figure out about where you are and save your dying ass.
 )
 
 var/global/list/default_medbay_channels = list(

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -59,6 +59,7 @@ em						{font-style: normal;font-weight: bold;}
 .supradio				{color: #5F4519;}
 .srvradio				{color: #6eaa2c;}
 .expradio				{color: #555555;}
+.emergradio				{color: #cc3300;}
 
 /* Miscellaneous */
 .name					{font-weight: bold;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -59,7 +59,7 @@ em						{font-style: normal;font-weight: bold;}
 .supradio				{color: #5F4519;}
 .srvradio				{color: #6eaa2c;}
 .expradio				{color: #555555;}
-.emergradio				{color: #cc3300;}
+.emergradio				{color: #000000;	background-color: #ffbb77;}
 
 /* Miscellaneous */
 .name					{font-weight: bold;}

--- a/maps/southern_cross/southern_cross_presets.dm
+++ b/maps/southern_cross/southern_cross_presets.dm
@@ -76,7 +76,7 @@ var/const/NETWORK_MAIN_OUTPOST = "Main Outpost"
 	)
 
 /obj/machinery/telecomms/receiver/preset_right/southerncross
-	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, EXP_FREQ)
+	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, EXP_FREQ, PANIC_FREQ)	//mithra edit - panic button.
 
 /obj/machinery/telecomms/bus/preset_two/southerncross
 	freq_listening = list(SUP_FREQ, SRV_FREQ, EXP_FREQ)
@@ -100,5 +100,6 @@ var/const/NETWORK_MAIN_OUTPOST = "Main Outpost"
 		num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 		num2text(SUP_FREQ) = list(access_cargo),
 		num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
-		num2text(EXP_FREQ) = list(access_explorer)
+		num2text(EXP_FREQ) = list(access_explorer),
+		num2text(PANIC_FREQ) = list(access_medical_equip,access_security)	//mithra edit - panic button.
 	)

--- a/mithrastation.dme
+++ b/mithrastation.dme
@@ -2969,4 +2969,6 @@
 #include "modular_mithra\multiphase\gun.dm"
 #include "modular_mithra\multiphase\locker.dm"
 #include "modular_mithra\multiphase\projectile.dm"
+#include "modular_mithra\radio_panic_button\radio.dm"
+#include "modular_mithra\radio_panic_button\encryption_keys.dm"
 // END_INCLUDE

--- a/mithrastation.dme
+++ b/mithrastation.dme
@@ -1,4 +1,4 @@
-// DM Environment file for MithraStations.dme.
+// DM Environment file for MithraStation.dme.
 // All manual changes should be made outside the BEGIN_ and END_ blocks.
  // New source code should be placed in .dm files: choose File/New --> Code File.
 // BEGIN_INTERNALS

--- a/modular_mithra/radio_panic_button/README.MD
+++ b/modular_mithra/radio_panic_button/README.MD
@@ -2,7 +2,7 @@
 
 ## *Quick start guide*
 1. Press the UI icon, or right-click the radio you wish to activate the emergency function on and select "Toggle Emergency Function".
-2. The radio will change channel to the emergency channel, notify the channel that you have activated your panic alarm, and the microphone will be hot - as you speak or people around you speak, it will relay to the emergency channel.
+2. If the radio has an emergency function available, the radio will change channel to the emergency channel, notify the channel that you have activated your panic alarm, and the microphone will be hot - as you speak or people around you speak, it will relay to the emergency channel.
 3. Press the UI icon again, or right-click and select "Toggle Emergency Function" again, to deactivate it.
 
 ## *In-depth Explanations - Frontend*

--- a/modular_mithra/radio_panic_button/README.MD
+++ b/modular_mithra/radio_panic_button/README.MD
@@ -1,0 +1,115 @@
+# Radio panic button user manual
+
+## *Quick start guide*
+1. Press the UI icon, or right-click the radio you wish to activate the emergency function on and select "Toggle Emergency Function".
+2. The radio will change channel to the emergency channel, notify the channel that you have activated your panic alarm, and the microphone will be hot - as you speak or people around you speak, it will relay to the emergency channel.
+3. Press the UI icon again, or right-click and select "Toggle Emergency Function" again, to deactivate it.
+
+## *In-depth Explanations - Frontend*
+
+### Panic alarm activation and deactivation
+Some radios will now be equipped with a panic alarm. Those that are, will have the headset in question with a UI element at the top left corner of your screen that you can click. Click it once to activate, click it again to deactivate.
+
+If you are handcuffed or otherwise restrained, you can activate the panic alarm by right-clicking the radio and clicking "Toggle Emergency Function". This will take about five seconds and will also send a visible message to nearby people to alert them of your shenanigans.
+
+Activating the alarm will send the emergency channel an alert that your panic function has been activated, plus the name of the area you are in, to assist emergency responders in finding you. It will also lock out the channel controls, so any assailant can't change the channel without deactivating the panic alarm, which will tip security off (see below).
+
+![Example of the activation message.](https://i.imgur.com/CKj41hr.png)
+
+Deactivating the alarm will send the emergency channel an alert that your panic function has been deactivated and who deactivated it, so they know that everything's OK or if your assailant is trying shonky business.
+
+### Which radios?
+
+#### The following get a panic alarm:
+
+* All shortwave radios have a panic alarm.
+* All security headsets, plus Colony Director and Head of Personnel headsets, have one as well, due to the fact that they're all high-value targets.
+* Centcomm, Nanotrasen Rep, and Admin Omni-channel headsets also have one, as they are all a result of admin intervention (spawning the characters or the headsets). Central and NT are also high-value targets.
+
+---
+
+#### The following do NOT get a panic alarm:
+
+* Intercoms do not have a panic alarm. Intercoms are anchored to the wall; players are not.
+* The AI radio does not have a panic alarm. The AI has tons of channels it can scream for help on.
+* Borg radios do not have a panic alarm. They can ask for the AI's assistance through a special channel.
+* Headsets not listed above do not have a panic alarm.
+
+
+### Who can hear the channel?
+
+* For shortwave radios: You will need either medical equipment access or security access to hear the channel.
+* For headsets: 
+  * The AI, Security and Medical (including HoS and CMO) can hear the channel by default. 
+  * Medical-Science headsets have access to it since they're medical, but it is deactivated by default since it's technically not part of their job.
+  * Heads of Staff have access to the channel, but it is deactivated by default since it's not their department and there's probably someone else there that's more qualified to answer the calls.
+  * ERT, NT/Centcomm and Admin Omni-channel headsets can also hear the channel by default.
+
+## *In-depth Explanations - Backend*
+
+### Code Locations
+
+* Channel frequency: [/code/controllers/communications.dm](/code/controllers/communications.dm)
+* Shortwave radio channel access: [/code/game/objects/items/devices/radio/radio.dm](/code/game/objects/items/devices/radio/radio.dm)
+* Chat CSS: [/code/stylesheet.dm](/code/stylesheet.dm)
+* Encryption key-based access: [./encryption_keys.dm](radio_panic_button/encryption_keys.dm)
+* Which radios get it, which don't, and the actual code: [./radio.dm](radio_panic_button/radio.dm)
+
+
+### Variable explanations
+
+#### Function variables (changing will directly affect functionality)
+
+* `action_button_name` - Name of the UI element at the top left corner of the screen.
+* `can_toggle_emergency_mode` - Whether or not the radio's emergency function can be toggled.
+* `panic_mode_will_turn_off_speaker` - Whether or not the panic function will disable the radio's speaker. 
+* `freqlock` - Whether or not the radio's frequency adjustment controls are locked out.
+
+---
+	
+#### Storage variables (changing will only confuse the proc that calls it)
+
+* `panic_prev_frequency` - The frequency the radio was on prior to the panic function being activated.
+* `panic_speaker_state` - Whether or not the radio's speaker was enabled prior to the panic function being activated.
+* `panic_mic_state` - Whether or not the radio's microphone was on continuous-transmit prior to the panic function being activated.
+* `panic_frequency_lock` - Whether or not the radio's current frequency lock setting is due to the panic alarm being activated. 
+  * 0: Not activated by proc, radio frequency will still be locked when we deactivate.
+  * 1: Activated by proc, radio frequency will be unlocked when we deactivate.
+* `panic_enabled` - Whether or not the emergency function is currently active.
+
+### Proc explanations
+
+#### panic_alarm
+```DM
+/obj/item/device/radio/proc/panic_alarm(mob/user, bypass_checks = FALSE)
+```
+
+Runs the sanity checks, then calls `toggle_panic_alarm`.
+
+Variables:
+* `mob/user` - The user.
+* `bypass_checks` - Whether we should bypass the sanity checks for incapacitation, if the radio has an emergency mode, et cetera. Intended for admin use only.
+
+Returns:
+* null: User was trying to use it with restraints, and was moved or further incapacitated.
+* 0: Sanity checks failed.
+* 1: Sanity checks passed, and `toggle_panic_alarm` was called.
+
+---
+
+#### toggle_panic_alarm
+```DM
+/obj/item/device/radio/proc/toggle_panic_alarm(mob/user, sanity_checks_pass = FALSE, admin_called = TRUE)
+```
+
+Toggles the panic alarm.
+
+Variables:
+* `mob/user` - The user.
+* `sanity_checks_pass` - Used in the check for malformed proc calls. If this is false, the proc assumes it didn't go through the sanity checks and calls `CRASH()`, aborting the proc.
+* `admin_called` - Used in the check for malformed proc calls. If this is true and `sanity_checks_pass` is false, the proc assumes the malformed proc call was due to an administrator calling the proc directly, and sends feedback to chat.
+
+Returns:
+* null: Proc aborted.
+* 0: Wire check failed.
+* 1: Panic function toggled successfully.

--- a/modular_mithra/radio_panic_button/encryption_keys.dm
+++ b/modular_mithra/radio_panic_button/encryption_keys.dm
@@ -1,0 +1,59 @@
+// code/game/objects/items/devices/radio/encryptionkey.dm
+// code/game/objects/items/devices/radio/encryptionkey_vr.dm
+
+
+//Medical
+/obj/item/device/encryptionkey/headset_med
+	channels = list("Medical" = 1, "Emergency" = 1)
+
+//Medical research
+//Has access since it's medical, but since they're also the research side of medical, it's disabled by default.
+/obj/item/device/encryptionkey/headset_medsci
+	channels = list("Medical" = 1, "Science" = 1, "Emergency" = 0)
+
+//Security
+/obj/item/device/encryptionkey/headset_sec
+	channels = list("Security" = 1, "Emergency" = 1)
+
+//Head of Security
+/obj/item/device/encryptionkey/heads/hos
+	channels = list("Security" = 1, "Command" = 1, "Emergency" = 1)
+
+//Chief Medical Officer
+/obj/item/device/encryptionkey/heads/cmo
+	channels = list("Medical" = 1, "Command" = 1, "Emergency" = 1)
+
+//Colony director
+//Has access since they're the Head Honcho, but disabled by default.
+/obj/item/device/encryptionkey/heads/captain
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 0, "Science" = 0, "Medical" = 0, "Supply" = 0, "Service" = 0, "Explorer" = 0, "Emergency" = 0)
+
+//AIs
+/obj/item/device/encryptionkey/heads/ai_integrated
+	channels = list("Command" = 1, "Security" = 1, "Engineering" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Explorer" = 1, "Emergency" = 1)
+
+//Other heads of staff. Since it's not their department, they're disabled by default, but they can turn 'em back on if they care enough to
+
+//Research Director
+/obj/item/device/encryptionkey/heads/rd
+	channels = list("Command" = 1, "Science" = 1, "Explorer" = 1, "Emergency" = 0)
+
+//Chief Engineer
+/obj/item/device/encryptionkey/heads/ce
+	channels = list("Engineering" = 1, "Command" = 1, "Emergency" = 0)
+
+//Head of Personnel
+/obj/item/device/encryptionkey/heads/hop
+	channels = list("Supply" = 1, "Service" = 1, "Command" = 1, "Security" = 0, "Explorer" = 0, "Emergency" = 0)
+
+
+//These won't show up outside of admin intervention of some sort.
+
+//ERT/CentComm
+//They're saving your lives, so probably a good idea to have it enabled.
+/obj/item/device/encryptionkey/ert
+	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Emergency" = 1)
+
+//Admin intercoms
+/obj/item/device/encryptionkey/omni
+	channels = list("Mercenary" = 1, "Raider" = 1, "Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1, "Emergency" = 1)

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -11,10 +11,6 @@
 	var/panic_mic_state
 	var/panic_frequency_lock = FALSE		//Is the frequency locked because of us?
 
-/obj/item/device/radio/headset
-	can_toggle_emergency_mode = FALSE		//regular headsets don't get a panic function.
-	action_button_name = ""		//no panic alarm, so no helpful icon.
-
 /obj/item/device/radio/ui_action_click()
 	panic_alarm(usr)
 
@@ -119,3 +115,45 @@
 			panic_frequency_lock = FALSE
 			freqlock = FALSE
 		return TRUE
+		
+// Headsets
+// code/game/objects/items/devices/radio/headset.dm
+
+/obj/item/device/radio/headset
+	can_toggle_emergency_mode = FALSE		//regular headsets don't get a panic function.
+	action_button_name = ""		//no panic alarm, so no helpful icon.
+
+/obj/item/device/radio/headset/heads/ai_integrated
+	can_toggle_emergency_mode = FALSE		//AI has tons of channels it can scream on.
+	action_button_name = ""
+
+//This is the admin spawned one. It can access every channel.
+//Therefore, to give the admins as much room to do what they need for storytelling, we'll give it a panic alarm anyway.
+//It acts like a regular panic alarm, though, and will still lock out the frequency adjusting.
+/obj/item/device/radio/headset/omni
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+
+// Work in progress. Do not uncomment yet.
+
+/*
+
+// Due to the nature of their job, sec officers and CDir should get a panic function anyway.
+// Sec chases down criminals and are at risk of ambush.
+
+/obj/item/device/radio/headset/headset_sec
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+// CDir is a high value target due to the nature of his job. Plus, all-access is sweet.
+/obj/item/device/radio/headset/heads/captain
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+//HoP is a high value target due to the fact that they can be acting CDir and have a machine that can grant all-access.
+/obj/item/device/radio/headset/heads/hop
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+*/

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -47,15 +47,15 @@
 
 	if(user.incapacitated & INCAPACITATION_DEFAULT)	//if we are restrained or fully buckled, it'll be a little bit harder to use our panic button.
 		user.visible_message("<span class='warning'>[user] begins to reach for [src].</span>","<span class='notice'>You begin reaching for the panic button on [src].</span>")		//Give the hostage taker a chance to stop us.
-		if(do_after(user, 5 SECONDS)
-			toggle_panic_button(mob/user, TRUE, FALSE)
+		if(do_after(user, 5 SECONDS))
+			toggle_panic_button(user, TRUE, FALSE)
 			return TRUE
 		else		//you were moved, so sad...
 			to_chat(user,"<span class='warning'>You fail to activate \the [src]'s emergency function.</span>")
 			return FALSE
 
 	else		//we're not under arrest, so we get to go ahead and just press the damn thing.
-		toggle_panic_button(mob/user, TRUE, FALSE)
+		toggle_panic_button(user, TRUE, FALSE)
 		return TRUE
 
 

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -20,8 +20,9 @@
 	set category = "Object"
 	set src in usr
 	
-	if(can_toggle_emergency_mode)		//can we even toggle it?
-		panic_alarm(usr)		//Whether or not we can activate it will be checked in the checks.
+	
+	panic_alarm(usr)		//Whether or not we can activate it will be checked in the checks.
+
 
 
 //Panic alarm proc. Called when someone toggles the emergency function on their radio.
@@ -163,17 +164,6 @@
 	can_toggle_emergency_mode = FALSE
 	action_button_name = ""// code/game/objects/items/devices/radio/radio.dm
 
-//This is the admin spawned one. It can access every channel.
-//Therefore, to give the admins as much room to do what they need for storytelling, we'll give it a panic alarm anyway.
-//It acts like a regular panic alarm, though, and will still lock out the frequency adjusting.
-/obj/item/device/radio/headset/omni
-	can_toggle_emergency_mode = TRUE
-	action_button_name = "Toggle Emergency Function"
-
-
-// Work in progress.
-
-
 // Headsets are a special case here. They can enable the panic alarm should they
 // need to, but they lose the common channel since there's currently not a way
 // to broadcast just to the panic channel without changing the frequency. So, we
@@ -206,5 +196,30 @@
 // create IDs with CDir access, and he becomes the acting CDir should a need for
 // one arise. He is also responsible for Ian's protection.
 /obj/item/device/radio/headset/heads/hop
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+// Admin spawned
+
+// This is the admin spawned one. It can access every channel. Therefore, to 
+// give the admins as much room to do what they need for story-telling, we'll 
+// give it a panic alarm anyway. It acts like a regular panic alarm, though, and
+// will still lock out the frequency adjusting.
+/obj/item/device/radio/headset/omni
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+// ERT and Centcomm headsets. They probably don't need it since they're checking
+// on or saving your crew, but since they're admin spawned, we'll give 'em it
+// anyways, just in case.
+/obj/item/device/radio/headset/centcom
+	can_toggle_emergency_mode = TRUE
+	action_button_name = "Toggle Emergency Function"
+
+// Nanotrasen representatives. They're a high value target, due to the fact that
+// they're supposed to be corporate executives, and kidnapping or killing one
+// would be a high-profile event that NT's competitors would love to capitalise
+// on. Plus, admin spawned, so we'll give 'em one.
+/obj/item/device/radio/headset/nanotrasen
 	can_toggle_emergency_mode = TRUE
 	action_button_name = "Toggle Emergency Function"

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -1,0 +1,121 @@
+// code/game/objects/items/devices/radio/radio.dm
+
+/obj/item/device/radio
+	action_button_name = "Toggle Emergency Function"		//helpful icon at top of screen.
+	var/can_toggle_emergency_mode = TRUE		//Can the panic function be toggled?
+	var/panic_enabled = FALSE
+	
+	//Storage variables.
+	var/panic_prev_frequency
+	var/panic_speaker_state
+	var/panic_mic_state
+	var/panic_frequency_lock = FALSE		//Is the frequency locked because of us?
+
+/obj/item/device/radio/headset
+	can_toggle_emergency_mode = FALSE		//regular headsets don't get a panic function.
+	action_button_name = ""		//no panic alarm, so no helpful icon.
+
+/obj/item/device/radio/ui_action_click()
+	panic_alarm(usr)
+
+//Panic alarm proc. Called when someone toggles the emergency function on their radio.
+/obj/item/device/radio/proc/panic_alarm(mob/user, bypass_checks = FALSE)
+	if(!user)		//Null check, so if you bypass stuff it doesn't break things
+		user = usr
+	ASSERT(user)	//null check, so if there wasn't a usr it doesn't break things.
+	if(!src)		//null check.
+		return FALSE
+
+	if(!bypass_checks)		//Should the need arise, admins can bypass the checks (e.g. for events).
+		if(!can_toggle_emergency_mode)		//can we even toggle it?
+			return FALSE
+
+		if(!(ishuman(user) || issilicon(user)))		//ghosts, simplemobs, etc
+			to_chat(user, "<span class='warning'>You lack the required dexterity to toggle \the [src]'s panic function.</span>")
+			return FALSE
+
+		if(user.stat != CONSCIOUS)		//are we unconscious or dead?
+			to_chat(user, "<span class='warning'>You cannot activate \the [src]'s panic function in your current state.</span>")
+			return FALSE
+
+		if(user.incapacitated & INCAPACITATION_DISABLED)		//If you are knocked down but conscious, stunned, or knocked out.
+		// NOTE: Restraints (e.g. handcuffed) are intentionally left out of this check!
+			to_chat(user, "<span class='warning'>You cannot activate \the [src]'s panic function in your current state.</span>")
+			return FALSE
+
+// All the checks have either passed or been bypassed so far, so we definitely CAN use the panic button.
+
+	if(user.incapacitated & INCAPACITATION_DEFAULT)	//if we are restrained or fully buckled, it'll be a little bit harder to use our panic button.
+		user.visible_message("<span class='warning'>[user] begins to reach for [src].</span>","<span class='notice'>You begin reaching for the panic button on [src].</span>")		//Give the hostage taker a chance to stop us.
+		if(do_after(user, 5 SECONDS)
+			toggle_panic_button(mob/user, TRUE, FALSE)
+			return TRUE
+		else		//you were moved, so sad...
+			to_chat(user,"<span class='warning'>You fail to activate \the [src]'s emergency function.</span>")
+			return FALSE
+
+	else		//we're not under arrest, so we get to go ahead and just press the damn thing.
+		toggle_panic_button(mob/user, TRUE, FALSE)
+		return TRUE
+
+
+/obj/item/device/radio/proc/toggle_panic_alarm(mob/user, sanity_checks_pass = FALSE, admin_called = TRUE)
+	if(!sanity_checks_pass)
+		/* 
+		 *Okay, I'm going to go off on a tangent for a second here. This proc
+		 * has NO sanity checks whatsoever. Therefore, we need to check and see
+		 * if the proper sanity checks have already been performed. If they were
+		 * not, then either the proc was called directly by admin intervention,
+		 * or by a faulty passthrough. The admin_called parameter is only used 
+		 * to tell if an adminstrator called the proc directly, and give feed-
+		 * back to them to correct their mistake.
+		 */
+		if(admin_called)		//This was never set, so we assume admin intervention.
+			//give feedback to the admin trying
+			message_admins("[usr]/([usr.key]) - operating on \"[src]\" at ([loc.x], [loc.y], [loc.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>): it is dangerous to call toggle_panic_alarm() directly, crashing proc")
+
+			//log to console.
+			CRASH("[usr] attempted to call proc directly without bypassing safeguards")
+		else
+			CRASH("[src] at [loc.x], [loc.y], [loc.z]: Sanity checks did not complete before this proc was called")
+
+	if(wires.IsIndexCut(WIRE_TRANSMIT) || wires.IsIndexCut(WIRE_SIGNAL) || wires.IsIndexCut(WIRE_RECEIVE))		//all our wires gotta be intact, yo.
+		to_chat(user, "<span class='warning'>\icon[src] Nothing happens...</span>")
+		return FALSE
+
+	panic_enabled = !panic_enabled		//toggle panic alarm
+	to_chat(user, "<span class='notice'>You [panic_enabled ? "activate" : "deactivate"] \the [src]'s emergency function.</span>")
+	if(panic_enabled)		//We're now enabled.
+		//First things first, let's store our old frequency, mic and speaker states so we can recall them later.
+		panic_prev_frequency = frequency	//frequency
+		panic_speaker_state = listening		//speaker state
+		panic_mic_state = broadcasting		//mic state
+		
+		//We also want to check and see if the frequency is locked. If not, we should lock it and make a note somewhere that we were the ones to lock it.
+		if(!freqlock)
+			freqlock = TRUE
+			panic_frequency_lock = TRUE
+
+		//now let's shut off our speaker, in case we're already on the panic alarm channel, so as not to tip off our assailants, and then broadcast a warning to those listening in that we're in trouble.
+		listening = FALSE
+		global_announcer.autosay("Radio emergency function activated by [user] in [get_area(src)]. Hotmike in 2 seconds.", "[src]", "Emergency")
+		
+		//wait 2 seconds before we hotmike.
+		spawn(20)
+			frequency = PANIC_FREQ
+			broadcasting = TRUE			//Hotmike so emergency responders can hear what's going on around you, e.g. shouting
+		return TRUE
+	else		//We're now disabled.
+		//Let everyone know the emergency has passed.
+		global_announcer.autosay("Radio emergency function deactivated by [user].", "[src]", "Emergency")
+		
+		//recall our previous frequency, mic status, and speaker status.
+		frequency = panic_prev_frequency
+		listening = panic_speaker_state
+		broadcasting = panic_mic_state
+		
+		//Check if the frequency was locked because of us. If so, clear that flag and unlock it.
+		if(panic_frequency_lock)
+			panic_frequency_lock = FALSE
+			freqlock = FALSE
+		return TRUE

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -34,24 +34,24 @@
 			to_chat(user, "<span class='warning'>You cannot activate \the [src]'s panic function in your current state.</span>")
 			return FALSE
 
-		if(user.incapacitated & INCAPACITATION_DISABLED)		//If you are knocked down but conscious, stunned, or knocked out.
+		if(user.incapacitated() & INCAPACITATION_DISABLED)		//If you are knocked down but conscious, stunned, or knocked out.
 		// NOTE: Restraints (e.g. handcuffed) are intentionally left out of this check!
 			to_chat(user, "<span class='warning'>You cannot activate \the [src]'s panic function in your current state.</span>")
 			return FALSE
 
 // All the checks have either passed or been bypassed so far, so we definitely CAN use the panic button.
 
-	if(user.incapacitated & INCAPACITATION_DEFAULT)	//if we are restrained or fully buckled, it'll be a little bit harder to use our panic button.
+	if(user.incapacitated() & INCAPACITATION_DEFAULT)	//if we are restrained or fully buckled, it'll be a little bit harder to use our panic button.
 		user.visible_message("<span class='warning'>[user] begins to reach for [src].</span>","<span class='notice'>You begin reaching for the panic button on [src].</span>")		//Give the hostage taker a chance to stop us.
 		if(do_after(user, 5 SECONDS))
-			toggle_panic_button(user, TRUE, FALSE)
+			toggle_panic_alarm(user, TRUE, FALSE)
 			return TRUE
 		else		//you were moved, so sad...
 			to_chat(user,"<span class='warning'>You fail to activate \the [src]'s emergency function.</span>")
 			return FALSE
 
 	else		//we're not under arrest, so we get to go ahead and just press the damn thing.
-		toggle_panic_button(user, TRUE, FALSE)
+		toggle_panic_alarm(user, TRUE, FALSE)
 		return TRUE
 
 

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -20,11 +20,9 @@
 	set category = "Object"
 	set src in usr
 	
-	if(!panic_enabled)		//no sense in having this proc if it has no panic alarm...
-		verbs -= /obj/item/device/radio/verb/emergency
+	if(can_toggle_emergency_mode)		//can we even toggle it?
+		panic_alarm(usr)		//Whether or not we can activate it will be checked in the checks.
 
-	else
-		panic_alarm(usr)
 
 //Panic alarm proc. Called when someone toggles the emergency function on their radio.
 /obj/item/device/radio/proc/panic_alarm(mob/user, bypass_checks = FALSE)
@@ -36,6 +34,7 @@
 
 	if(!bypass_checks)		//Should the need arise, admins can bypass the checks (e.g. for events).
 		if(!can_toggle_emergency_mode)		//can we even toggle it?
+			to_chat(user, "<span class='warning'>This radio does not have an emergency function you can activate.</span>")
 			return FALSE
 
 		if(!(ishuman(user) || issilicon(user)))		//ghosts, simplemobs, etc
@@ -158,6 +157,11 @@
 /obj/item/device/radio/intercom
 	can_toggle_emergency_mode = FALSE		//Intercoms get no panic function, since players can be dragged away.
 	action_button_name = ""		//See above.
+	
+// Borgs do not get a panic function.
+/obj/item/device/radio/borg
+	can_toggle_emergency_mode = FALSE
+	action_button_name = ""// code/game/objects/items/devices/radio/radio.dm
 
 //This is the admin spawned one. It can access every channel.
 //Therefore, to give the admins as much room to do what they need for storytelling, we'll give it a panic alarm anyway.

--- a/modular_mithra/radio_panic_button/radio.dm
+++ b/modular_mithra/radio_panic_button/radio.dm
@@ -60,7 +60,7 @@
 			return TRUE
 		else		//you were moved, so sad...
 			to_chat(user,"<span class='warning'>You fail to activate \the [src]'s emergency function.</span>")
-			return FALSE
+			return null	//for proc feedback
 
 	else		//we're not under arrest, so we get to go ahead and just press the damn thing.
 		toggle_panic_alarm(user, TRUE, FALSE)

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -16,6 +16,8 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 		.sciradio				{color: #993399;}
 		.supradio				{color: #7F6539;}
 		.srvradio				{color: #6eaa2c;}
+		<!-- Mithra Addition - panic button -->
+		.emergradio				{color: #ff6600;}
 	</style>
 </head>
 


### PR DESCRIPTION
* Shortwave radios, and some headsets, now have a panic function.
* The panic function can be activated while handcuffed, but will take 5 seconds and will alert anyone nearby to your shenanigans.
* See user manual located at `modular_mithra/radio_panic_button/readme.md` for more details.