### PR TITLE
Increases number of end of round votes. 

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -7,7 +7,7 @@ datum/controller/transfer_controller
 	var/shift_last_vote = 0 //VOREStation Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
-	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 4) //VOREStation Edit //Change this "1" to how many extend votes you want there to be. //Mithra Addition
+	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 6) //VOREStation Edit //Change this "1" to how many extend votes you want there to be. //Mithra Addition
 	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval //VOREStation Edit
 	processing_objects += src
 


### PR DESCRIPTION
# WARNING: READ BEFORE MERGE.

This is the Github side of the 'minimum round time' tweak. You will need to alter the configuration if you should decide to merge this, to halve the minimum round time.

This is intended to increase the "round time range" to 6 hours (2\~8 hour rounds, range of 6h) from 4 hours (4\~8) hours. **If you do not edit the configuration to reflect this, the round time will probably be 4\~12 hours.**

